### PR TITLE
PLM-185: Fix reporting of the `lagTime` during the replication phase

### DIFF
--- a/main.go
+++ b/main.go
@@ -993,9 +993,9 @@ type statusResponse struct {
 	Info string `json:"info,omitempty"`
 
 	// LagTime is the current lag time in logical seconds.
-	LagTime int64 `json:"lagTime,omitempty"`
+	LagTime int64 `json:"lagTime"`
 	// EventsProcessed is the number of events processed.
-	EventsProcessed int64 `json:"eventsProcessed,omitempty"`
+	EventsProcessed int64 `json:"eventsProcessed"`
 	// LastReplicatedOpTime is the last replicated operation time.
 	LastReplicatedOpTime string `json:"lastReplicatedOpTime,omitempty"`
 

--- a/main.go
+++ b/main.go
@@ -689,7 +689,7 @@ func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	res.EventsProcessed = &status.Repl.EventsProcessed
+	res.EventsProcessed = status.Repl.EventsProcessed
 	res.LagTime = status.TotalLagTime
 
 	if !status.Repl.LastReplicatedOpTime.IsZero() {
@@ -703,7 +703,7 @@ func (s *server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		LagTime:   status.InitialSyncLagTime,
 
 		CloneCompleted:     status.Clone.IsFinished(),
-		EstimatedCloneSize: &status.Clone.EstimatedTotalSize,
+		EstimatedCloneSize: status.Clone.EstimatedTotalSize,
 		ClonedSize:         status.Clone.CopiedSize,
 	}
 
@@ -993,9 +993,9 @@ type statusResponse struct {
 	Info string `json:"info,omitempty"`
 
 	// LagTime is the current lag time in logical seconds.
-	LagTime *int64 `json:"lagTime,omitempty"`
+	LagTime int64 `json:"lagTime,omitempty"`
 	// EventsProcessed is the number of events processed.
-	EventsProcessed *int64 `json:"eventsProcessed,omitempty"`
+	EventsProcessed int64 `json:"eventsProcessed,omitempty"`
 	// LastReplicatedOpTime is the last replicated operation time.
 	LastReplicatedOpTime string `json:"lastReplicatedOpTime,omitempty"`
 
@@ -1006,10 +1006,10 @@ type statusResponse struct {
 // statusInitialSyncResponse represents the initial sync status in the /status response.
 type statusInitialSyncResponse struct {
 	// LagTime is the lag time in logical seconds until the initial sync completed.
-	LagTime *int64 `json:"lagTime,omitempty"`
+	LagTime int64 `json:"lagTime,omitempty"`
 
 	// EstimatedCloneSize is the estimated total size of the clone.
-	EstimatedCloneSize *uint64 `json:"estimatedCloneSize,omitempty"`
+	EstimatedCloneSize uint64 `json:"estimatedCloneSize,omitempty"`
 	// ClonedSize is the size of the data that has been cloned.
 	ClonedSize uint64 `json:"clonedSize"`
 

--- a/plm/plm.go
+++ b/plm/plm.go
@@ -58,9 +58,9 @@ type Status struct {
 	Error error
 
 	// TotalLagTime is the current lag time in logical seconds between source and target clusters.
-	TotalLagTime *int64
+	TotalLagTime int64
 	// InitialSyncLagTime is the lag time during the initial sync.
-	InitialSyncLagTime *int64
+	InitialSyncLagTime int64
 	// InitialSyncCompleted indicates if the initial sync is completed.
 	InitialSyncCompleted bool
 
@@ -247,7 +247,7 @@ func (ml *PLM) Status(ctx context.Context) *Status {
 
 	if s.Repl.IsStarted() {
 		intialSyncLag := max(int64(s.Clone.FinishTS.T)-int64(s.Repl.LastReplicatedOpTime.T), 0)
-		s.InitialSyncLagTime = &intialSyncLag
+		s.InitialSyncLagTime = intialSyncLag
 		s.InitialSyncCompleted = s.Repl.LastReplicatedOpTime.After(s.Clone.FinishTS)
 	}
 
@@ -263,10 +263,10 @@ func (ml *PLM) Status(ctx context.Context) *Status {
 		switch {
 		case !s.Repl.LastReplicatedOpTime.IsZero():
 			totalLag := int64(sourceTime.T) - int64(s.Repl.LastReplicatedOpTime.T)
-			s.TotalLagTime = &totalLag
+			s.TotalLagTime = totalLag
 		case !s.Clone.StartTS.IsZero():
 			totalLag := int64(sourceTime.T) - int64(s.Clone.StartTS.T)
-			s.TotalLagTime = &totalLag
+			s.TotalLagTime = totalLag
 		}
 	}
 

--- a/plm/plm.go
+++ b/plm/plm.go
@@ -246,7 +246,6 @@ func (ml *PLM) Status(ctx context.Context) *Status {
 	}
 
 	if s.Repl.IsStarted() {
-		s.InitialSyncLagTime = 0
 		s.InitialSyncCompleted = s.Repl.LastReplicatedOpTime.After(s.Clone.FinishTS)
 	}
 

--- a/plm/plm.go
+++ b/plm/plm.go
@@ -246,8 +246,7 @@ func (ml *PLM) Status(ctx context.Context) *Status {
 	}
 
 	if s.Repl.IsStarted() {
-		intialSyncLag := max(int64(s.Clone.FinishTS.T)-int64(s.Repl.LastReplicatedOpTime.T), 0)
-		s.InitialSyncLagTime = intialSyncLag
+		s.InitialSyncLagTime = 0
 		s.InitialSyncCompleted = s.Repl.LastReplicatedOpTime.After(s.Clone.FinishTS)
 	}
 
@@ -270,7 +269,9 @@ func (ml *PLM) Status(ctx context.Context) *Status {
 		}
 	}
 
-	s.InitialSyncLagTime = s.TotalLagTime
+	if !s.InitialSyncCompleted {
+		s.InitialSyncLagTime = s.TotalLagTime
+	}
 
 	return s
 }


### PR DESCRIPTION
[![PLM-185](https://badgen.net/badge/JIRA/PLM-185/green)](https://jira.percona.com/browse/PLM-185) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is the fix for the lagTime reporting when executing `plm status` command.

During replication phase, wrong `initialSync.lagTime` is reported by `plm status` command:
```
{
  "ok": true,
  "state": "running",
  "info": "Replicating Changes",
  "lagTime": 39,
  "eventsProcessed": 1224000,
  "lastReplicatedOpTime": "1756107985.158",
  "initialSync": {
    "lagTime": 39, <--- initial sync is done, but lagTime is reported and it's equal to the replication lagTime
    "estimatedCloneSize": 6688694535,
    "clonedSize": 6688694535,
    "completed": true,
    "cloneCompleted": true
  }
}
```

After the fix, `plm status` reports zero `initialSynx.lagTime` (omitted) when initSync phase is done:
```
{
  "ok": true,
  "state": "running",
  "info": "Replicating Changes",
  "lagTime": 3,
  "eventsProcessed": 42001,
  "lastReplicatedOpTime": "1756110105.85",
  "initialSync": {
    "estimatedCloneSize": 7803400769,
    "clonedSize": 7803400769,
    "completed": true,
    "cloneCompleted": true
  }
}
```

[PLM-185]: https://perconadev.atlassian.net/browse/PLM-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ